### PR TITLE
Add 2025 slabs

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -52,11 +52,26 @@ const _INCOME_TAX_SLABS_NEW_REGIME_2023 = [
     ],
   ],
 ];
+const _INCOME_TAX_SLABS_NEW_REGIME_2025 = [
+  [
+    Infinity,
+    [
+      [lakhs(4), 0],
+      [lakhs(8), 5],
+      [lakhs(12), 10],
+      [lakhs(16), 15],
+      [lakhs(20), 20],
+      [lakhs(24), 25],
+      [Infinity, 30],
+    ],
+  ],
+];
 const _INCOME_TAX_SLABS_OLD_REGIME = [
   [2023, _INCOME_TAX_SLABS_OLD_REGIME_2023],
 ];
 const _INCOME_TAX_SLABS_NEW_REGIME = [
   [2023, _INCOME_TAX_SLABS_NEW_REGIME_2023],
+  [2025, _INCOME_TAX_SLABS_NEW_REGIME_2025],
 ];
 const INCOME_TAX_SLABS_BY_REGIME = {
   old: _INCOME_TAX_SLABS_OLD_REGIME,

--- a/src/lib/slabs/income-tax.ts
+++ b/src/lib/slabs/income-tax.ts
@@ -53,12 +53,28 @@ const _INCOME_TAX_SLABS_NEW_REGIME_2023: IncomeTaxSlabs[number][1] = [
   ],
 ];
 
+const _INCOME_TAX_SLABS_NEW_REGIME_2025: IncomeTaxSlabs[number][1] = [
+  [
+    Infinity,
+    [
+      [lakhs(4), 0],
+      [lakhs(8), 5],
+      [lakhs(12), 10],
+      [lakhs(16), 15],
+      [lakhs(20), 20],
+      [lakhs(24), 25],
+      [Infinity, 30],
+    ],
+  ],
+];
+
 const _INCOME_TAX_SLABS_OLD_REGIME: IncomeTaxSlabs = [
   [2023, _INCOME_TAX_SLABS_OLD_REGIME_2023],
 ] as const;
 
 const _INCOME_TAX_SLABS_NEW_REGIME: IncomeTaxSlabs = [
   [2023, _INCOME_TAX_SLABS_NEW_REGIME_2023],
+  [2025, _INCOME_TAX_SLABS_NEW_REGIME_2025],
 ];
 
 export const INCOME_TAX_SLABS_BY_REGIME: Record<Regime, IncomeTaxSlabs> = {

--- a/src/types/years.ts
+++ b/src/types/years.ts
@@ -1,1 +1,1 @@
-export type FinancialYearStartIn = 2023 | 2024;
+export type FinancialYearStartIn = 2023 | 2024 | 2025;


### PR DESCRIPTION
https://www.news18.com/business/live-updates-income-tax-slab-changes-budget-2025-news-nirmala-sitharaman-new-vs-old-liveblog-9210181.html